### PR TITLE
DP-1561 : apply configmap subpath patch to latest release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ sparkctl/sparkctl
 spark-on-k8s-operator
 sparkctl/sparkctl-linux-amd64
 sparkctl/sparkctl-darwin-amd64
+.DS_Store
+values.yaml

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -19,7 +19,7 @@ package config
 const (
 	// DefaultSparkConfDir is the default directory for Spark configuration files if not specified.
 	// This directory is where the Spark ConfigMap is mounted in the driver and executor containers.
-	DefaultSparkConfDir = "/etc/spark/conf"
+	DefaultSparkConfDir = "/opt/spark/conf"
 	// SparkConfigMapVolumeName is the name of the ConfigMap volume of Spark configuration files.
 	SparkConfigMapVolumeName = "spark-configmap-volume"
 	// DefaultHadoopConfDir is the default directory for Spark configuration files if not specified.

--- a/pkg/webhook/patch.go
+++ b/pkg/webhook/patch.go
@@ -17,18 +17,19 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (
@@ -42,7 +43,7 @@ type patchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-func patchSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
+func patchSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication, client kubernetes.Interface) []patchOperation {
 	var patchOps []patchOperation
 
 	if util.IsDriverPod(pod) {
@@ -51,7 +52,7 @@ func patchSparkPod(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperat
 
 	patchOps = append(patchOps, addVolumes(pod, app)...)
 	patchOps = append(patchOps, addGeneralConfigMaps(pod, app)...)
-	patchOps = append(patchOps, addSparkConfigMap(pod, app)...)
+	patchOps = append(patchOps, addSparkConfigMap(pod, app, client)...)
 	patchOps = append(patchOps, addHadoopConfigMap(pod, app)...)
 	patchOps = append(patchOps, getPrometheusConfigPatches(pod, app)...)
 	patchOps = append(patchOps, addTolerations(pod, app)...)
@@ -292,22 +293,45 @@ func addEnvironmentVariable(pod *corev1.Pod, envName, envValue string) *patchOpe
 	return &patchOperation{Op: "add", Path: path, Value: value}
 }
 
-func addSparkConfigMap(pod *corev1.Pod, app *v1beta2.SparkApplication) []patchOperation {
+func addSparkConfigMap(pod *corev1.Pod, app *v1beta2.SparkApplication, client kubernetes.Interface) []patchOperation {
 	var patchOps []patchOperation
 	sparkConfigMapName := app.Spec.SparkConfigMap
 	if sparkConfigMapName != nil {
+		i := findContainer(pod)
+		glog.V(2).Infof("Existing spark configmaps %v", pod.Spec.Containers[i].VolumeMounts)
+		mountIndex := findVolumeMountIndex(&pod.Spec.Containers[i])
+		if mountIndex >= 0 {
+			// Change existing mount configuration to spark.properties
+			glog.V(2).Infof("Replacing VolumeMount in %v", mountIndex)
+			mnt := pod.Spec.Containers[i].VolumeMounts[mountIndex]
+			propertiesfile := "spark.properties"
+			mnt.MountPath = mnt.MountPath + "/" + propertiesfile
+			mnt.SubPath = propertiesfile
+			replaceMountPath := fmt.Sprintf("/spec/containers/%d/volumeMounts/%d", i, mountIndex)
+			glog.V(2).Infof("New VolumeMount %v", replaceMountPath)
+			patchOps = append(patchOps, patchOperation{Op: "replace", Path: replaceMountPath, Value: mnt})
+		}
+
 		patchOps = append(patchOps, addConfigMapVolume(pod, *sparkConfigMapName, config.SparkConfigMapVolumeName))
-		vmPatchOp := addConfigMapVolumeMount(pod, config.SparkConfigMapVolumeName, config.DefaultSparkConfDir)
-		if vmPatchOp == nil {
-			return nil
+		// Get config map keys
+		cm, err := client.CoreV1().ConfigMaps(app.Namespace).Get(context.TODO(), *sparkConfigMapName, metav1.GetOptions{})
+		if err == nil {
+			for key := range cm.Data {
+				mountPath := fmt.Sprintf("/opt/spark/conf/%s", key)
+				glog.V(2).Infof("Adding mountPath %v", mountPath)
+				patchOps = append(patchOps, *addConfigMapVolumeMountSubpath(pod, config.SparkConfigMapVolumeName,
+					mountPath, key))
+			}
+		} else {
+			glog.Errorf("Could not get custom spark config map: %v", err)
 		}
-		patchOps = append(patchOps, *vmPatchOp)
-		envPatchOp := addEnvironmentVariable(pod, config.SparkConfDirEnvVar, config.DefaultSparkConfDir)
-		if envPatchOp == nil {
-			return nil
-		}
-		patchOps = append(patchOps, *envPatchOp)
 	}
+
+	envPatchOp := addEnvironmentVariable(pod, config.SparkConfDirEnvVar, config.DefaultSparkConfDir)
+	if envPatchOp == nil {
+		return nil
+	}
+	patchOps = append(patchOps, *envPatchOp)
 	return patchOps
 }
 
@@ -848,4 +872,28 @@ func addShareProcessNamespace(pod *corev1.Pod, app *v1beta2.SparkApplication) *p
 		return nil
 	}
 	return &patchOperation{Op: "add", Path: "/spec/shareProcessNamespace", Value: *shareProcessNamespace}
+}
+
+// Subpath support
+func addConfigMapVolumeMountSubpath(pod *corev1.Pod, configMapVolumeName string, mountPath string, subpath string) *patchOperation {
+	mount := corev1.VolumeMount{
+		Name:      configMapVolumeName,
+		ReadOnly:  true,
+		MountPath: mountPath,
+		SubPath:   subpath,
+	}
+	return addVolumeMount(pod, mount)
+}
+
+func findVolumeMountIndex(container *corev1.Container) int {
+	i := 0
+	// Find the driver or executor container in the pod.
+	for ; i < len(container.VolumeMounts); i++ {
+		glog.V(2).Infof("Processing mount %v(name %v)", container.VolumeMounts[i], container.VolumeMounts[i].Name)
+		volumeMountName := container.VolumeMounts[i].Name
+		if volumeMountName == "spark-conf-volume" || volumeMountName == "spark-conf-volume-driver" || volumeMountName == "spark-conf-volume-exec" {
+			return i
+		}
+	}
+	return -1
 }

--- a/pkg/webhook/patch_test.go
+++ b/pkg/webhook/patch_test.go
@@ -24,12 +24,12 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
+	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
-	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/config"
+	kubeclientfake "k8s.io/client-go/kubernetes/fake"
 )
 
 func TestPatchSparkPod_OwnerReference(t *testing.T) {
@@ -1792,7 +1792,8 @@ func TestPatchSparkPod_Lifecycle(t *testing.T) {
 }
 
 func getModifiedPod(pod *corev1.Pod, app *v1beta2.SparkApplication) (*corev1.Pod, error) {
-	patchOps := patchSparkPod(pod.DeepCopy(), app)
+	fakeClient := kubeclientfake.NewSimpleClientset()
+	patchOps := patchSparkPod(pod.DeepCopy(), app, fakeClient)
 	patchBytes, err := json.Marshal(patchOps)
 	if err != nil {
 		return nil, err

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -276,7 +276,7 @@ func (wh *WebHook) serve(w http.ResponseWriter, r *http.Request) {
 	var reviewResponse *admissionv1.AdmissionResponse
 	switch review.Request.Resource {
 	case podResource:
-		reviewResponse, whErr = mutatePods(review, wh.lister, wh.sparkJobNamespace)
+		reviewResponse, whErr = mutatePods(review, wh.lister, wh.sparkJobNamespace, wh.clientset)
 	case sparkApplicationResource:
 		if !wh.enableResourceQuotaEnforcement {
 			unexpectedResourceType(w, review.Request.Resource.String())
@@ -354,7 +354,6 @@ func denyRequest(w http.ResponseWriter, reason string, code int) {
 func (wh *WebHook) selfRegistration(webhookConfigName string) error {
 	mwcClient := wh.clientset.AdmissionregistrationV1().MutatingWebhookConfigurations()
 	vwcClient := wh.clientset.AdmissionregistrationV1().ValidatingWebhookConfigurations()
-
 	caCert, err := readCertFile(wh.certProvider.caCertFile)
 	if err != nil {
 		return err
@@ -539,7 +538,7 @@ func admitScheduledSparkApplications(review *admissionv1.AdmissionReview, enforc
 func mutatePods(
 	review *admissionv1.AdmissionReview,
 	lister crdlisters.SparkApplicationLister,
-	sparkJobNs string) (*admissionv1.AdmissionResponse, error) {
+	sparkJobNs string, client kubernetes.Interface) (*admissionv1.AdmissionResponse, error) {
 	raw := review.Request.Object.Raw
 	pod := &corev1.Pod{}
 	if err := json.Unmarshal(raw, pod); err != nil {
@@ -563,7 +562,7 @@ func mutatePods(
 		return nil, fmt.Errorf("failed to get SparkApplication %s/%s: %v", review.Request.Namespace, appName, err)
 	}
 
-	patchOps := patchSparkPod(pod, app)
+	patchOps := patchSparkPod(pod, app, client)
 	if len(patchOps) > 0 {
 		glog.V(2).Infof("Pod %s in namespace %s is subject to mutation", pod.GetObjectMeta().GetName(), review.Request.Namespace)
 		patchBytes, err := json.Marshal(patchOps)


### PR DESCRIPTION
Issue addressed and the solution used are outlined [here](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/216). Let's try this and contribute back if this works well.


To use this patched branch..
1) Checkout to this branch and build the docker image in the root dir.
2) Update helm chart values to use the image built in the last step and install the chart.

To add a custom `hive-site.xml`

1) Add a hive configmap `k create configmap hive-config --from-file=hive-site.xml`
2) Add `sparkConfigMap: hive-config` in the `SparkApplication` spec.